### PR TITLE
Updating data extraction to use {DAISIEprep} v0.4.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,4 @@
 ^bash$
 ^doc$
 ^Meta$
+^\.zenodo\.json$

--- a/R/default_params_doc.R
+++ b/R/default_params_doc.R
@@ -31,6 +31,11 @@
 #' given to the species within each island colonist, therefore the species name
 #' given does not need to match the clade_name of the island colonist (which is
 #' a representative species for the clade)
+#' @param rate_model A character string determining the discrete character
+#' Markov model (Mk) to be used. Only used when `extraction_method = "asr"`.
+#' Options are equal-rates `"ER"`, all rates different `"ARD"`, symmetrical
+#' `"SYM"`, only stepwise transitions `"SUEDE"` and only stepwise transitions
+#' to neighbouring states `"SRD".`
 #'
 #' @return Nothing
 #' @keywords internal
@@ -47,6 +52,7 @@ default_params_doc <- function(bar,
                                daisie_status,
                                extraction_method,
                                num_missing_species,
-                               species_name) {
+                               species_name,
+                               rate_model) {
   #Nothing
 }

--- a/R/extract_species.R
+++ b/R/extract_species.R
@@ -16,7 +16,8 @@ extract_species <- function(checklist_file_name,
                             phylo_file_name,
                             dna_or_complete,
                             daisie_status,
-                            extraction_method) {
+                            extraction_method,
+                            rate_model) {
 
   # load the full raw data checklist of bird species of madagascar
   checklist <- read_checklist(file_name = checklist_file_name)
@@ -89,6 +90,7 @@ extract_species <- function(checklist_file_name,
       DAISIEprep::add_asr_node_states,
       asr_method = "mk",
       tie_preference = "mainland",
+      rate_model = rate_model,
       future.seed = TRUE
     )
   }

--- a/inst/scripts/extract_data/amp/extract_amp_complete_ds_asr.R
+++ b/inst/scripts/extract_data/amp/extract_amp_complete_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Jetz_Pyron_complete_posterior_100.rds",
   dna_or_complete = "complete",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_complete <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/amp/extract_amp_dna_ds_asr.R
+++ b/inst/scripts/extract_data/amp/extract_amp_dna_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Jetz_Pyron_dna_posterior_100.rds",
   dna_or_complete = "DNA",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_dna <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/bird/extract_bird_complete_ds_asr.R
+++ b/inst/scripts/extract_data/bird/extract_bird_complete_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Jetz_complete_posterior_100.rds",
   dna_or_complete = "complete",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_complete <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/bird/extract_bird_dna_ds_asr.R
+++ b/inst/scripts/extract_data/bird/extract_bird_dna_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Jetz_dna_posterior_100.rds",
   dna_or_complete = "DNA",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_dna <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/nvm/extract_nvm_complete_ds_asr.R
+++ b/inst/scripts/extract_data/nvm/extract_nvm_complete_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Upham_complete_posterior_100.rds",
   dna_or_complete = "complete",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_complete <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/nvm/extract_nvm_dna_ds_asr.R
+++ b/inst/scripts/extract_data/nvm/extract_nvm_dna_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Upham_dna_posterior_100.rds",
   dna_or_complete = "DNA",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_dna <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/squa/extract_squa_complete_ds_asr.R
+++ b/inst/scripts/extract_data/squa/extract_squa_complete_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Tonini_complete_posterior_100.rds",
   dna_or_complete = "complete",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_complete <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/squa/extract_squa_dna_ds_asr.R
+++ b/inst/scripts/extract_data/squa/extract_squa_dna_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Tonini_dna_posterior_100.rds",
   dna_or_complete = "DNA",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_dna <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/vm/extract_vm_complete_ds_asr.R
+++ b/inst/scripts/extract_data/vm/extract_vm_complete_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Upham_complete_posterior_100.rds",
   dna_or_complete = "complete",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_complete <- island_data$multi_island_tbl

--- a/inst/scripts/extract_data/vm/extract_vm_dna_ds_asr.R
+++ b/inst/scripts/extract_data/vm/extract_vm_dna_ds_asr.R
@@ -8,7 +8,8 @@ island_data <- MadIsland::extract_species(
   phylo_file_name = "Upham_dna_posterior_100.rds",
   dna_or_complete = "DNA",
   daisie_status = TRUE,
-  extraction_method = "asr"
+  extraction_method = "asr",
+  rate_model = "ARD"
 )
 
 multi_island_tbl_dna <- island_data$multi_island_tbl

--- a/man/MadIsland-package.Rd
+++ b/man/MadIsland-package.Rd
@@ -4,7 +4,7 @@
 \name{MadIsland-package}
 \alias{MadIsland}
 \alias{MadIsland-package}
-\title{MadIsland: Package to hold all the scripts to reproduce paper on colonisation and divesification history of Madagascar's tetrapods}
+\title{MadIsland: An R package to hold all the scripts to reproduce paper on colonisation and diversification history of Madagascar's tetrapods}
 \description{
 Reproduce all analyses and plots from the paper on the colonisation and diversification history of Madagascar's tetrapods. Note that this package is tailored to use the Hábrók High Performance Computing Cluster (HPCC) \url{https://wiki.hpc.rug.nl/habrok/start} therefore rerunning certain analyses sequentially on a desktop/laptop will be time consuming.
 }

--- a/man/default_params_doc.Rd
+++ b/man/default_params_doc.Rd
@@ -17,7 +17,8 @@ default_params_doc(
   daisie_status,
   extraction_method,
   num_missing_species,
-  species_name
+  species_name,
+  rate_model
 )
 }
 \arguments{
@@ -64,6 +65,12 @@ missing species are assigned. This is done by matching the species name
 given to the species within each island colonist, therefore the species name
 given does not need to match the clade_name of the island colonist (which is
 a representative species for the clade)}
+
+\item{rate_model}{A character string determining the discrete character
+Markov model (Mk) to be used. Only used when `extraction_method = "asr"`.
+Options are equal-rates `"ER"`, all rates different `"ARD"`, symmetrical
+`"SYM"`, only stepwise transitions `"SUEDE"` and only stepwise transitions
+to neighbouring states `"SRD".`}
 }
 \value{
 Nothing

--- a/man/extract_species.Rd
+++ b/man/extract_species.Rd
@@ -13,7 +13,8 @@ extract_species(
   phylo_file_name,
   dna_or_complete,
   daisie_status,
-  extraction_method
+  extraction_method,
+  rate_model
 )
 }
 \arguments{
@@ -36,6 +37,12 @@ migrated}
 whether to use the `min` or `asr` algorithms for the
 `DAISIEprep::extract_island_species()` extraction process, see `DAISIEprep`
 documentation for more information.}
+
+\item{rate_model}{A character string determining the discrete character
+Markov model (Mk) to be used. Only used when `extraction_method = "asr"`.
+Options are equal-rates `"ER"`, all rates different `"ARD"`, symmetrical
+`"SYM"`, only stepwise transitions `"SUEDE"` and only stepwise transitions
+to neighbouring states `"SRD".`}
 }
 \value{
 List with:

--- a/renv.lock
+++ b/renv.lock
@@ -88,7 +88,7 @@
     },
     "DAISIEprep": {
       "Package": "DAISIEprep",
-      "Version": "0.3.2",
+      "Version": "0.4.0",
       "Source": "Bioconductor",
       "Repository": "CRAN",
       "Requirements": [
@@ -104,7 +104,7 @@
         "scales",
         "tibble"
       ],
-      "Hash": "893692f58db63aacca9d757f17401ad5"
+      "Hash": "dd92e6dd897015d5921a2ec24f38f6a5"
     },
     "DAISIEutils": {
       "Package": "DAISIEutils",
@@ -259,7 +259,7 @@
     },
     "RcppArmadillo": {
       "Package": "RcppArmadillo",
-      "Version": "0.12.8.0.0",
+      "Version": "0.12.8.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -269,11 +269,11 @@
         "stats",
         "utils"
       ],
-      "Hash": "847fc78bd9f83f55696b4b016482f7ed"
+      "Hash": "e78bbbb81a5dcd71a4bd3268d6ede0b1"
     },
     "RcppEigen": {
       "Package": "RcppEigen",
-      "Version": "0.3.3.9.4",
+      "Version": "0.3.4.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -282,7 +282,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "acb0a5bf38490f26ab8661b467f4f53a"
+      "Hash": "df49e3306f232ec28f1604e36a202847"
     },
     "SparseM": {
       "Package": "SparseM",
@@ -398,13 +398,14 @@
     },
     "bslib": {
       "Package": "bslib",
-      "Version": "0.6.1",
+      "Version": "0.7.0",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "base64enc",
         "cachem",
+        "fastmap",
         "grDevices",
         "htmltools",
         "jquerylib",
@@ -415,7 +416,7 @@
         "rlang",
         "sass"
       ],
-      "Hash": "c0d8599494bc7fb408cd206bbdd9cab0"
+      "Hash": "8644cc53f43828f19133548195d7e59e"
     },
     "cachem": {
       "Package": "cachem",
@@ -430,7 +431,7 @@
     },
     "callr": {
       "Package": "callr",
-      "Version": "3.7.3",
+      "Version": "3.7.6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -439,7 +440,7 @@
         "processx",
         "utils"
       ],
-      "Hash": "9b2191ede20fa29828139b9900922e51"
+      "Hash": "d7e13f49c19103ece9e58ad2d83a7354"
     },
     "castor": {
       "Package": "castor",
@@ -503,13 +504,13 @@
     },
     "codetools": {
       "Package": "codetools",
-      "Version": "0.2-19",
+      "Version": "0.2-20",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "c089a619a7fae175d149d89164f8c7d8"
+      "Hash": "61e097f35917d342622f21cdc79c256e"
     },
     "colorspace": {
       "Package": "colorspace",
@@ -587,13 +588,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.2.0",
+      "Version": "5.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "ce88d13c0b10fe88a37d9c59dba2d7f9"
+      "Hash": "411ca2c03b1ce5f548345d2fc2685f7a"
     },
     "deSolve": {
       "Package": "deSolve",
@@ -639,14 +640,14 @@
     },
     "digest": {
       "Package": "digest",
-      "Version": "0.6.34",
+      "Version": "0.6.35",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "7ede2ee9ea8d3edbf1ca84c1e333ad1a"
+      "Hash": "698ece7ba5a4fa4559e3d537e7ec3d31"
     },
     "doParallel": {
       "Package": "doParallel",
@@ -684,17 +685,6 @@
         "vctrs"
       ],
       "Hash": "fedd9d00c2944ff00a0e2696ccf048ec"
-    },
-    "ellipsis": {
-      "Package": "ellipsis",
-      "Version": "0.3.2",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "rlang"
-      ],
-      "Hash": "bb0eec2fe32e88d9e2836c2f73ea2077"
     },
     "evaluate": {
       "Package": "evaluate",
@@ -792,7 +782,7 @@
     },
     "future": {
       "Package": "future",
-      "Version": "1.33.1",
+      "Version": "1.33.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -803,11 +793,11 @@
         "parallelly",
         "utils"
       ],
-      "Hash": "e57e292737f7a4efa9d8a91c5908222c"
+      "Hash": "fd7b1d69d16d0d114e4fa82db68f184c"
     },
     "future.apply": {
       "Package": "future.apply",
-      "Version": "1.11.1",
+      "Version": "1.11.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -817,7 +807,7 @@
         "parallel",
         "utils"
       ],
-      "Hash": "455e00c16ec193c8edcf1b2b522b3288"
+      "Hash": "afe1507511629f44572e6c53b9baeb7c"
     },
     "generics": {
       "Package": "generics",
@@ -862,9 +852,9 @@
     },
     "ggplot2": {
       "Package": "ggplot2",
-      "Version": "3.4.4",
+      "Version": "3.5.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "MASS",
         "R",
@@ -883,7 +873,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "313d31eff2274ecf4c1d3581db7241f9"
+      "Hash": "52ef83f93f74833007f193b2d4c159a2"
     },
     "ggplotify": {
       "Package": "ggplotify",
@@ -903,8 +893,9 @@
     },
     "ggtree": {
       "Package": "ggtree",
-      "Version": "3.10.0",
+      "Version": "3.10.1",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.18",
       "Requirements": [
         "R",
         "ape",
@@ -926,23 +917,25 @@
         "utils",
         "yulab.utils"
       ],
-      "Hash": "f009cfa13d3884c01cc6300443e397eb"
+      "Hash": "6b825b70c84bd46133ac63b6dccedef0"
     },
     "gh": {
       "Package": "gh",
-      "Version": "1.4.0",
+      "Version": "1.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "cli",
         "gitcreds",
+        "glue",
         "httr2",
         "ini",
         "jsonlite",
+        "lifecycle",
         "rlang"
       ],
-      "Hash": "03533b1c875028233598f848fda44c4c"
+      "Hash": "fbbbc48eba7a6626a08bb365e44b563b"
     },
     "gitcreds": {
       "Package": "gitcreds",
@@ -956,14 +949,14 @@
     },
     "globals": {
       "Package": "globals",
-      "Version": "0.16.2",
+      "Version": "0.16.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "codetools"
       ],
-      "Hash": "baa9585ab4ce47a9f4618e671778cc6f"
+      "Hash": "2580567908cafd4f187c1e5a91e98b7f"
     },
     "glue": {
       "Package": "glue",
@@ -1030,20 +1023,19 @@
     },
     "htmltools": {
       "Package": "htmltools",
-      "Version": "0.5.7",
+      "Version": "0.5.8",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "base64enc",
         "digest",
-        "ellipsis",
         "fastmap",
         "grDevices",
         "rlang",
         "utils"
       ],
-      "Hash": "2d7b3857980e0e0d0a1fd6f11928ab0f"
+      "Hash": "149431ee39aba5bdc264112c8ff94444"
     },
     "httr": {
       "Package": "httr",
@@ -1062,7 +1054,7 @@
     },
     "httr2": {
       "Package": "httr2",
-      "Version": "1.0.0",
+      "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1079,11 +1071,11 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "e2b30f1fc039a0bab047dd52bb20ef71"
+      "Hash": "03d741c92fda96d98c3a3f22494e3b4a"
     },
     "igraph": {
       "Package": "igraph",
-      "Version": "2.0.2",
+      "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1102,7 +1094,7 @@
         "utils",
         "vctrs"
       ],
-      "Hash": "e3baa015afa83d9f1b748db5a2aedb5a"
+      "Hash": "c3b7d801d722e26e4cd888e042bf9af5"
     },
     "ini": {
       "Package": "ini",
@@ -1182,7 +1174,7 @@
     },
     "lattice": {
       "Package": "lattice",
-      "Version": "0.22-5",
+      "Version": "0.22-6",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1193,7 +1185,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "7c5e89f04e72d6611c77451f6331a091"
+      "Hash": "cc5ac1ba4c238c7ca9fa6a87ca11a7e2"
     },
     "lazyeval": {
       "Package": "lazyeval",
@@ -1300,14 +1292,14 @@
     },
     "munsell": {
       "Package": "munsell",
-      "Version": "0.5.0",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "colorspace",
         "methods"
       ],
-      "Hash": "6dfe8bf774944bd5595785e3229d8771"
+      "Hash": "4fd8900853b746af55b81fda99da7695"
     },
     "naturalsort": {
       "Package": "naturalsort",
@@ -1364,7 +1356,7 @@
     },
     "parallelly": {
       "Package": "parallelly",
-      "Version": "1.37.0",
+      "Version": "1.37.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1372,7 +1364,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "8da17de8b15c89b574269fc414ff4e20"
+      "Hash": "5410df8d22bd36e616f2a2343dbb328c"
     },
     "patchwork": {
       "Package": "patchwork",
@@ -1495,7 +1487,7 @@
     },
     "pkgbuild": {
       "Package": "pkgbuild",
-      "Version": "1.4.3",
+      "Version": "1.4.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1506,7 +1498,7 @@
         "desc",
         "processx"
       ],
-      "Hash": "c0143443203205e6a2760ce553dafc24"
+      "Hash": "a29e8e134a460a01e0ca67a4763c595b"
     },
     "pkgconfig": {
       "Package": "pkgconfig",
@@ -1583,7 +1575,7 @@
     },
     "processx": {
       "Package": "processx",
-      "Version": "3.8.3",
+      "Version": "3.8.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1592,7 +1584,7 @@
         "ps",
         "utils"
       ],
-      "Hash": "82d48b1aec56084d9438dbf98087a7e9"
+      "Hash": "0c90a7d71988856bad2a2a45dd871bb9"
     },
     "progress": {
       "Package": "progress",
@@ -1667,9 +1659,12 @@
     "renv": {
       "Package": "renv",
       "Version": "1.0.5",
-      "OS_type": null,
-      "Repository": "CRAN",
-      "Source": "Repository"
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "utils"
+      ],
+      "Hash": "32c3f93e8360f667ca5863272ec8ba6a"
     },
     "reshape2": {
       "Package": "reshape2",
@@ -1697,7 +1692,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.25",
+      "Version": "2.26",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1710,14 +1705,13 @@
         "jsonlite",
         "knitr",
         "methods",
-        "stringr",
         "tinytex",
         "tools",
         "utils",
         "xfun",
         "yaml"
       ],
-      "Hash": "d65e35823c817f09f4de424fcdfa812a"
+      "Hash": "9b148e7f95d33aac01f31282d49e4f44"
     },
     "rncl": {
       "Package": "rncl",
@@ -1744,14 +1738,14 @@
     },
     "rstudioapi": {
       "Package": "rstudioapi",
-      "Version": "0.15.0",
+      "Version": "0.16.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "5564500e25cffad9e22244ced1379887"
+      "Hash": "96710351d642b70e8f02ddeb237c46a7"
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.8",
+      "Version": "0.4.9",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1761,7 +1755,7 @@
         "rappdirs",
         "rlang"
       ],
-      "Hash": "168f9353c76d4c4b0a0bbf72e2c2d035"
+      "Hash": "d53dbfddf695303ea4ad66f86e99b95d"
     },
     "scales": {
       "Package": "scales",
@@ -1960,7 +1954,7 @@
     },
     "tidyselect": {
       "Package": "tidyselect",
-      "Version": "1.2.0",
+      "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1972,7 +1966,7 @@
         "vctrs",
         "withr"
       ],
-      "Hash": "79540e5fcd9e0435af547d885f184fd5"
+      "Hash": "829f27b9c4919c16b593794a6344d6c0"
     },
     "tidytree": {
       "Package": "tidytree",
@@ -1998,18 +1992,24 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.49",
+      "Version": "0.50",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "5ac22900ae0f386e54f1c307eca7d843"
+      "Hash": "be7a76845222ad20adb761f462eed3ea"
     },
     "treeio": {
       "Package": "treeio",
-      "Version": "1.26.0",
-      "Source": "Bioconductor",
+      "Version": "1.27.0.002",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteUsername": "GuangchuangYu",
+      "RemoteRepo": "treeio",
+      "RemoteRef": "devel",
+      "RemoteSha": "f6686330e437867add5dc80ef2e5db85c866c6c3",
       "Requirements": [
         "R",
         "ape",
@@ -2021,13 +2021,14 @@
         "stats",
         "tibble",
         "tidytree",
-        "utils"
+        "utils",
+        "yulab.utils"
       ],
-      "Hash": "a09203806aa0bc49965563ca7016620e"
+      "Hash": "545643f9a451c86eea21504c2ac59b3b"
     },
     "usethis": {
       "Package": "usethis",
-      "Version": "2.2.2",
+      "Version": "2.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2054,7 +2055,7 @@
         "withr",
         "yaml"
       ],
-      "Hash": "60e51f0b94d0324dc19e44110098fa9f"
+      "Hash": "d524fd42c517035027f866064417d7e6"
     },
     "utf8": {
       "Package": "utf8",
@@ -2139,7 +2140,7 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.42",
+      "Version": "0.43",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2147,7 +2148,7 @@
         "stats",
         "tools"
       ],
-      "Hash": "fd1349170df31f7a10bd98b0189e85af"
+      "Hash": "ab6371d8653ce5f2f9290f4ec7b42a8e"
     },
     "xml2": {
       "Package": "xml2",

--- a/renv.lock
+++ b/renv.lock
@@ -1666,13 +1666,10 @@
     },
     "renv": {
       "Package": "renv",
-      "Version": "1.0.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
-      "Requirements": [
-        "utils"
-      ],
-      "Hash": "41b847654f567341725473431dd0d5ab"
+      "Version": "1.0.5",
+      "OS_type": null,
+      "Repository": "CRAN",
+      "Source": "Repository"
     },
     "reshape2": {
       "Package": "reshape2",


### PR DESCRIPTION
Updates to:

- Data extraction scripts to use the ARD model
- Update {renv} and the packages in the `renv.lock` file (including {DAISIEprep} v0.3.2 -> v0.4.0)